### PR TITLE
fix: add terrain entities

### DIFF
--- a/EffectZones.cs
+++ b/EffectZones.cs
@@ -77,6 +77,7 @@ public class EffectZones : BaseSettingsPlugin<EffectZonesSettings>
         {
             GameController?.EntityListWrapper?.ValidEntitiesByType[EntityType.Effect] ?? [],
             GameController?.EntityListWrapper?.ValidEntitiesByType[EntityType.MonsterMods] ?? [],
+            GameController?.EntityListWrapper?.ValidEntitiesByType[EntityType.Terrain] ?? [],
         };
 
         var entityList = entityLists.SelectMany(list => list).ToList();


### PR DESCRIPTION
Allows for motes to be added.
```
Metadata/Terrain/Leagues/Sanctum/Objects/SanctumMote

Metadata/Effects/Spells/monsters_effects/League_Sanctum/SacredWaterDrop/sacred_water_drop.ao
```